### PR TITLE
Fixed bug under get_process_info

### DIFF
--- a/api/windows.py
+++ b/api/windows.py
@@ -26,6 +26,8 @@ def get_process_info():
         process_name = element['processName']
         for process in psutil.process_iter():
             process_info = process.as_dict(attrs=['pid', 'name'])
+            if process_info['name'] == None:
+                continue
             if process_info['name'].lower() in process_name:
                 element['pid'] = process_info['pid']
                 return element


### PR DESCRIPTION
Added continue statement at line 30 in get_process_info when process_info has a None type for its name. Previously the function would just exit preventing the program from finding an Adobe app